### PR TITLE
Add prepack script and bump packageManager to yarn 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "yarn && jest --maxWorkers=2",
     "watch:types": "yarn run build:types --watch",
     "watch:babel": "yarn run build:babel --watch",
-    "watch": "concurrently \"yarn:watch:*\""
+    "watch": "concurrently \"yarn:watch:*\"",
+    "prepack": "yarn build"
   },
   "peerDependencies": {
     "graphql": "16.5.0",
@@ -39,5 +40,5 @@
     "graphql": "16.5.0"
   },
   "main": "dist/index.js",
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.13.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/graphql-codegen-object-types",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "GraphQL Code Generator plugin for generating an interface with all object types from your schema",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Yarn 4.13.0 passes configuration (including `npmMinimalAgeGate`) as environment variables when packing git-hosted dependencies. Older Yarn versions don't recognise these settings and fail with `YN0058`.

```
➤ YN0058: │ @fullscript/graphql-codegen-object-types@https://github.com/Fullscript/graphql-codegen-object-types.git#commit=d1b7fac463fad5d2f7781065776e8a63ce38e260: Packing the package failed (exit code 1, logs can be found here: /private/var/folders/qs/jwzhlgwn6y7b4vzxvk13ztgc0000gp/T/xfs-08467133/pack.log)
```

Additionally, this requires a build step to produce `dist/`, but has no `prepack` script. Without it, Yarn's git dependency pipeline skips the build entirely and the pack fails because the declared `main` entry point doesn't exist. Adding `"prepack": "yarn build"` ensures dependencies are installed and the build runs before packing.

Lemme know if this makes sense!

## Testing

- In a consuming project that uses Yarn 4.13.0 with `npmMinimalAgeGate` configured, update the git dependency reference to point at the new commit
- Bust your yarn cache with `yarn cache clean`
- Run `yarn install` and confirm the `YN0058` packing error doesn't happen
- Verify the package resolves and installs successfully